### PR TITLE
37 feature add args codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,27 +25,32 @@ Please read [Contributor Guide](.github/CONTRIBUTING_DOC/CONTRIBUTING.md) for mo
 
 ## Features
 
-- [X] `markdown` subcommand generate markdown badge by program language or framework, this subcommand `only output into stdout`
-  - markdown can use git url or http url to get git info (only support github now)
-  - can cover by `arg0` to fast get badge output, event not in git managed project
-  - `--no-common-badges` no badges common subcommand for this repo (default: false)
-  - `--golang` add golang badges for github project
-  - `--rust` add rust badges for github project
-    - `--rust-crates` value    crates.io name badges for this repo, if not set, use repo name
-  - `--node` add node badges for github project
-  - `--npm` add npm badges for github project
-  - `--docker-user` `--docker-repo` add docker badges for github project
+- [X] `markdown` subcommand generate markdown badge by program language or framework, this
+  subcommand `only output into stdout`
+    - markdown can use git url or http url to get git info (only support github now)
+      - if not set `--user` or `--repo` can input git url like `https//...` or `git@...` (v1.11.+)
+      - with empty `--user` or `--repo` and empty `arg0` will try to find out git info from current git project (v1.12.+)
+    - can cover by `arg0` to fast get badge output, event not in git managed project
+    - `--no-common-badges` no badges common subcommand for this repo (default: false)
+    - `--golang` add golang badges for github project
+    - `--rust` add rust badges for github project
+        - `--rust-crates` value crates.io name badges for this repo, if not set, use repo name
+    - `--node` add node badges for github project
+    - `--npm` add npm badges for github project
+    - `--docker-user` `--docker-repo` add docker badges for github project
 - [x] `badge` add badge at github project
-  - support badge same as `markdown` subcommand, different must use in `git` managed project
+    - support badge same as `markdown` subcommand, different must use in `git` managed project
 - [X] `template` add conventional template at .github and try add badge at README.md
-  - support badge same as `markdown` subcommand, different must use in `git` managed project
-  - `--coverage-folder-file` coverage folder file under targetFolder, does not affect files that are not in the template (default: false) 
-  - conventional contributing support `--language`
-    - `en-US`
-    - `zh-CN`
+    - support badge same as `markdown` subcommand, different must use in `git` managed project
+    - `--coverage-folder-file` coverage folder file under targetFolder, does not affect files that are not in the
+      template (default: false)
+    - conventional contributing support `--language`
+        - `en-US`
+        - `zh-CN`
 - [X] `action` fast add github action workflow (1.10.+), must set `--ci-*` to effective
-  - `--coverage-folder-file` coverage folder or file under targetFolder, does not affect files that are not in the template (default: false) 
-  -  `--ci-deploy-tag` add sample deploy by tag
+    - `--coverage-folder-file` coverage folder or file under targetFolder, does not affect files that are not in the
+      template (default: false)
+    - `--ci-deploy-tag` add sample deploy by tag
 - [ ] more perfect test case coverage
 
 ## usage
@@ -261,17 +266,17 @@ $ make helpDocker
 ### log
 
 - cli log use [github.com/sinlov/go-logger](https://github.com/bar-counter/slog)
-  - open debug log by env `CLI_VERBOSE=true` or global flag `--verbose`
+    - open debug log by env `CLI_VERBOSE=true` or global flag `--verbose`
 
 ```go
 package foo
 
 func action(c *cli.Context) error {
-  slog.Debug("SubCommand [ new ] start") // this not show at CLI_VERBOSE=false
+	slog.Debug("SubCommand [ new ] start") // this not show at CLI_VERBOSE=false
 
-  if c.Bool("lib") {
-    slog.Info("new lib mode")
-  }
-  return nil
+	if c.Bool("lib") {
+		slog.Info("new lib mode")
+	}
+	return nil
 }
 ```

--- a/command/common_subcommand/badge_markdown.go
+++ b/command/common_subcommand/badge_markdown.go
@@ -107,8 +107,10 @@ func BadgeByConfigWithMarkdown(
 		sb.WriteString("\n")
 
 		if branch != "" {
-			sb.WriteString(codecov_badges.GithubMarkdown(userName, repoName, branch))
-			sb.WriteString("\n")
+			if badgeConfig.CodeCovBadges {
+				sb.WriteString(codecov_badges.GithubMarkdown(userName, repoName, branch))
+				sb.WriteString("\n")
+			}
 		}
 		sb.WriteString(shields_badges.GithubLatestSemVerTagMarkdown(userName, repoName))
 		sb.WriteString("\n")
@@ -221,8 +223,10 @@ func BadgeByConfig(
 		sb.WriteString("\n")
 
 		if branch != "" {
-			sb.WriteString(codecov_badges.Github(userName, repoName, branch))
-			sb.WriteString("\n")
+			if badgeConfig.CodeCovBadges {
+				sb.WriteString(codecov_badges.Github(userName, repoName, branch))
+				sb.WriteString("\n")
+			}
 		}
 		sb.WriteString(shields_badges.GithubLatestSemVerTag(userName, repoName))
 		sb.WriteString("\n")

--- a/command/common_subcommand/badge_print.go
+++ b/command/common_subcommand/badge_print.go
@@ -82,7 +82,11 @@ func PrintBadgeByConfigWithMarkdown(
 		color.Greenf("\nCommon badges:\n")
 		fmt.Println(shields_badges.GithubLicenseMarkdown(userName, repoName))
 		if branch != "" {
-			fmt.Println(codecov_badges.GithubMarkdown(userName, repoName, branch))
+
+			if badgeConfig.CodeCovBadges {
+				fmt.Println(codecov_badges.GithubMarkdown(userName, repoName, branch))
+			}
+
 		}
 		fmt.Println(shields_badges.GithubLatestSemVerTagMarkdown(userName, repoName))
 		fmt.Println(shields_badges.GithubReleaseMarkdown(userName, repoName))
@@ -156,7 +160,9 @@ func PrintBadgeByConfig(
 		color.Greenf("\nCommon badges:\n")
 		fmt.Println(shields_badges.GithubLicense(userName, repoName))
 		if branch != "" {
-			fmt.Println(codecov_badges.Github(userName, repoName, branch))
+			if badgeConfig.CodeCovBadges {
+				fmt.Println(codecov_badges.Github(userName, repoName, branch))
+			}
 		}
 		fmt.Println(shields_badges.GithubLatestSemVerTag(userName, repoName))
 		fmt.Println(shields_badges.GithubRelease(userName, repoName))

--- a/command/subcommand_action/subCmdAction.go
+++ b/command/subcommand_action/subCmdAction.go
@@ -69,7 +69,7 @@ func (n *ActionCommand) Exec() error {
 func flag() []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{
-			Name:  "gitRootFolder",
+			Name:  constant.CliNameGitRootFolder,
 			Usage: "set add target git root folder, defaults is cli run path",
 			Value: "",
 		},
@@ -94,7 +94,7 @@ func flag() []cli.Flag {
 func withEntry(c *cli.Context) (*ActionCommand, error) {
 	globalEntry := command.CmdGlobalEntry()
 
-	gitRootFolder := c.String("gitRootFolder")
+	gitRootFolder := c.String(constant.CliNameGitRootFolder)
 	if gitRootFolder == "" {
 		dir, err := os.Getwd()
 		if err != nil {

--- a/command/subcommand_badge/subCmdBadge.go
+++ b/command/subcommand_badge/subCmdBadge.go
@@ -104,12 +104,12 @@ func (n *BadgeCommand) Exec() error {
 func flag() []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{
-			Name:  "gitRootFolder",
+			Name:  constant.CliNameGitRootFolder,
 			Usage: "set add target git root folder, defaults is cli run path",
 			Value: "",
 		},
 		&cli.StringFlag{
-			Name:  "remote",
+			Name:  constant.CliNameGitRemote,
 			Usage: "set git remote name, defaults is origin",
 			Value: "origin",
 		},
@@ -128,8 +128,8 @@ func flag() []cli.Flag {
 func withEntry(c *cli.Context) (*BadgeCommand, error) {
 	globalEntry := command.CmdGlobalEntry()
 
-	remote := c.String("remote")
-	gitRootFolder := c.String("gitRootFolder")
+	remote := c.String(constant.CliNameGitRemote)
+	gitRootFolder := c.String(constant.CliNameGitRootFolder)
 	if gitRootFolder == "" {
 		dir, err := os.Getwd()
 		if err != nil {

--- a/command/subcommand_markdown/subCmdMarkdown.go
+++ b/command/subcommand_markdown/subCmdMarkdown.go
@@ -95,8 +95,14 @@ func withEntry(c *cli.Context) (*MarkdownCommand, error) {
 				user = splitPath[1]
 				repo = splitPath[2]
 			}
-
 		}
+	}
+
+	if user == "" {
+		return nil, fmt.Errorf("need set --user, or can not find git repo user")
+	}
+	if repo == "" {
+		return nil, fmt.Errorf("need set --repo, or can not find git repo")
 	}
 
 	return &MarkdownCommand{

--- a/command/subcommand_markdown/subCmdMarkdown.go
+++ b/command/subcommand_markdown/subCmdMarkdown.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"github.com/bar-counter/slog"
 	giturls "github.com/chainguard-dev/git-urls"
+	"github.com/sinlov-go/go-git-tools/git_info"
 	"github.com/sinlov/gh-conventional-kit/command"
 	"github.com/sinlov/gh-conventional-kit/command/common_subcommand"
 	"github.com/sinlov/gh-conventional-kit/constant"
 	"github.com/sinlov/gh-conventional-kit/internal/urfave_cli"
 	"github.com/urfave/cli/v2"
+	"os"
 	"strings"
 )
 
@@ -37,6 +39,17 @@ func (n *MarkdownCommand) Exec() error {
 
 func flag() []cli.Flag {
 	return []cli.Flag{
+		&cli.StringFlag{
+			Name:  constant.CliNameGitRootFolder,
+			Usage: "set add target git root folder, defaults is cli run path, this will ignore --user and --repo or use arg0 to input git url",
+			Value: "",
+		},
+		&cli.StringFlag{
+			Name:  constant.CliNameGitRemote,
+			Usage: "set git remote name, defaults is origin, this will ignore --user and --repo or use arg0 to input git url",
+			Value: "origin",
+		},
+
 		&cli.StringFlag{
 			Name:    "user",
 			Aliases: []string{"u"},
@@ -95,6 +108,29 @@ func withEntry(c *cli.Context) (*MarkdownCommand, error) {
 				user = splitPath[1]
 				repo = splitPath[2]
 			}
+		} else {
+			slog.Debug("try find out at git repo")
+			remote := c.String(constant.CliNameGitRemote)
+			gitRootFolder := c.String(constant.CliNameGitRootFolder)
+			if gitRootFolder == "" {
+				dir, err := os.Getwd()
+				if err != nil {
+					return nil, fmt.Errorf("can not get target foler err: %v", err)
+				}
+				gitRootFolder = dir
+			}
+			_, err := git_info.IsPathGitManagementRoot(gitRootFolder)
+			if err != nil {
+				return nil, err
+			}
+			fistRemoteInfo, err := git_info.RepositoryFistRemoteInfo(gitRootFolder, remote)
+			if err != nil {
+				return nil, err
+			}
+			user = fistRemoteInfo.User
+			slog.Debugf("find git repo user: %s", user)
+			repo = fistRemoteInfo.Repo
+			slog.Debugf("find git repo: %s", repo)
 		}
 	}
 

--- a/command/subcommand_template/subCmdTemplate.go
+++ b/command/subcommand_template/subCmdTemplate.go
@@ -177,12 +177,12 @@ func (n *TemplateCommand) Exec() error {
 func flag() []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{
-			Name:  "gitRootFolder",
+			Name:  constant.CliNameGitRootFolder,
 			Usage: "set add target git root folder, defaults is cli run path",
 			Value: "",
 		},
 		&cli.StringFlag{
-			Name:  "remote",
+			Name:  constant.CliNameGitRemote,
 			Usage: "set git remote name, defaults is: origin",
 			Value: "origin",
 		},
@@ -212,8 +212,8 @@ func flag() []cli.Flag {
 func withEntry(c *cli.Context) (*TemplateCommand, error) {
 	globalEntry := command.CmdGlobalEntry()
 
-	remote := c.String("remote")
-	gitRootFolder := c.String("gitRootFolder")
+	remote := c.String(constant.CliNameGitRemote)
+	gitRootFolder := c.String(constant.CliNameGitRootFolder)
 	if gitRootFolder == "" {
 		dir, err := os.Getwd()
 		if err != nil {

--- a/constant/badge_flag.go
+++ b/constant/badge_flag.go
@@ -4,6 +4,8 @@ import "github.com/urfave/cli/v2"
 
 type BadgeConfig struct {
 	NoCommonBadges bool
+	CodeCovBadges  bool
+
 	GolangBadges   bool
 	RustBadges     bool
 	RustCratesName string
@@ -20,6 +22,12 @@ func BadgeFlags() []cli.Flag {
 			Name:  "no-common-badges",
 			Value: false,
 			Usage: "no badges common subcommand for this repo",
+		},
+
+		&cli.BoolFlag{
+			Name:  "codecov-badges",
+			Value: false,
+			Usage: "codecov badges for this repo",
 		},
 
 		&cli.BoolFlag{
@@ -64,6 +72,8 @@ func BadgeFlags() []cli.Flag {
 func BindBadgeConfig(c *cli.Context) *BadgeConfig {
 	return &BadgeConfig{
 		NoCommonBadges: c.Bool("no-common-badges"),
+		CodeCovBadges:  c.Bool("codecov-badges"),
+
 		GolangBadges:   c.Bool("golang"),
 		RustBadges:     c.Bool("rust"),
 		RustVersion:    c.String("rust-version"),

--- a/constant/flag.go
+++ b/constant/flag.go
@@ -1,0 +1,7 @@
+package constant
+
+const (
+	CliNameGitRootFolder = "gitRootFolder"
+
+	CliNameGitRemote = "remote"
+)

--- a/internal/filepath_plus/path_plus.go
+++ b/internal/filepath_plus/path_plus.go
@@ -84,9 +84,9 @@ func ReadFileAsByte(path string) ([]byte, error) {
 	if PathIsDir(path) {
 		return nil, fmt.Errorf("path is dir: %s", path)
 	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("path: %s read err: %v", path, err)
+	data, errRead := os.ReadFile(path)
+	if errRead != nil {
+		return nil, fmt.Errorf("path: %s read err: %v", path, errRead)
 	}
 
 	return data, nil


### PR DESCRIPTION
### Description of Changes

add `--codecov-badges` flag
with empty `--user` or `--repo` and empty `arg0` will try to find out git info from current git project (v1.12.+)

### Related Issues

#37 