### PR TITLE
feat(badge): update dependency badge to use GitHub reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
     - `--golang` add golang badges for github project
     - `--rust` add rust badges for github project
         - `--rust-crates` value crates.io name badges for this repo, if not set, use repo name
+        - use github reps badge for [deps.rs](https://deps.rs/) (1.17+)
     - `--node` add node badges for github project
     - `--npm` add npm badges for github project
     - `--docker-user` `--docker-repo` add docker badges for github project

--- a/command/common_subcommand/badge_markdown.go
+++ b/command/common_subcommand/badge_markdown.go
@@ -70,7 +70,7 @@ func BadgeByConfigWithMarkdown(
 			sb.WriteString("\n")
 			sb.WriteString(rust_badges.CratesLicenseHtmlMarkdown(cratesName, htmlMarkdownSize))
 			sb.WriteString("\n")
-			sb.WriteString(rust_badges.DepsRsCrateLatestHtmlMarkdown(cratesName, htmlMarkdownSize))
+			sb.WriteString(rust_badges.DepsRsGithubHtmlMarkdown(userName, repoName, htmlMarkdownSize))
 			sb.WriteString("\n")
 		} else {
 			sb.WriteString(rust_badges.DocsRsMarkdown(cratesName))
@@ -81,7 +81,7 @@ func BadgeByConfigWithMarkdown(
 			sb.WriteString("\n")
 			sb.WriteString(rust_badges.CratesLicenseMarkdown(cratesName))
 			sb.WriteString("\n")
-			sb.WriteString(rust_badges.DepsRsCrateLatestMarkdown(cratesName))
+			sb.WriteString(rust_badges.DepsRsGithub(userName, repoName))
 			sb.WriteString("\n")
 		}
 


### PR DESCRIPTION
feat #63

- Replace DepsRsCrateLatest with DepsRsGithub for HTML markdown
- Replace DepsRsCrateLatest with DepsRsGithub for plain markdown
- Update function calls to use GitHub username and repo name instead of crate name