### PR TITLE
fix(docker): update bake file renaming process

### DIFF
--- a/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
@@ -117,7 +117,17 @@ jobs:
         name: Rename meta bake definition file
         run: |
           mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
-          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          jq '
+            def scrub:
+              if type == "object" then
+                with_entries(select(.key != "buildx.build.provenance") | .value |= scrub)
+              elif type == "array" then
+                map(scrub)
+              else
+                .
+              end;
+            scrub
+          ' "${{ steps.meta.outputs.bake-file }}" > "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition

--- a/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
@@ -191,25 +191,15 @@ jobs:
       - name: Extract container image digest from bake output
         id: bake-output-container-image-digest
         run: |
-          jq '
-            def scrub:
-              if type == "object" then
-                with_entries(select(.key != "buildx.build.provenance") | .value |= scrub)
-              elif type == "array" then
-                map(scrub)
-              else
-                .
-              end;
-            scrub
-          ' "${{ steps.meta.outputs.bake-file }}" | jq -cr '.["${{ inputs.docker_bake_targets }}"]["containerimage.digest"]')" >>$GITHUB_OUTPUT
+          jq '.' "${{ runner.temp }}/${{ inputs.docker_bake_targets }}/bake-meta.json" | jq -cr '.["${{ inputs.docker_bake_targets }}"]["containerimage.digest"]' >>$GITHUB_OUTPUT
 
       -
         name: Export digest
         run: |
-          mkdir -p ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests
+          mkdir -p ${{ runner.temp }}/${{ inputs.docker_bake_targets }}/digests
           digest="${{ steps.bake-output-container-image-digest.outputs.digest }}"
-          touch "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/${digest#sha256:}"
-          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests
+          touch "${{ runner.temp }}/${{ inputs.docker_bake_targets }}/digests/${digest#sha256:}"
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets }}/digests
 
       -
         name: Upload digest

--- a/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
@@ -191,7 +191,17 @@ jobs:
       - name: Extract container image digest from bake output
         id: bake-output-container-image-digest
         run: |
-          echo "digest=$(echo '${{ steps.bake.outputs.metadata}}' | jq -cr '.["${{ inputs.docker_bake_targets }}"]["containerimage.digest"]')" >>$GITHUB_OUTPUT
+          jq '
+            def scrub:
+              if type == "object" then
+                with_entries(select(.key != "buildx.build.provenance") | .value |= scrub)
+              elif type == "array" then
+                map(scrub)
+              else
+                .
+              end;
+            scrub
+          ' "${{ steps.meta.outputs.bake-file }}" | jq -cr '.["${{ inputs.docker_bake_targets }}"]["containerimage.digest"]')" >>$GITHUB_OUTPUT
 
       -
         name: Export digest

--- a/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
@@ -131,7 +131,7 @@ jobs:
 
       -
         name: Upload meta bake definition
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: ${{ inputs.push_remote_flag }}
         with:
           name: bake-latest-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
@@ -190,8 +190,15 @@ jobs:
 
       - name: Extract container image digest from bake output
         id: bake-output-container-image-digest
+        env:
+          BAKE_METADATA: ${{ steps.bake.outputs.metadata }}
         run: |
-          jq '.' "${{ runner.temp }}/${{ inputs.docker_bake_targets }}/bake-meta.json" | jq -cr '.["${{ inputs.docker_bake_targets }}"]["containerimage.digest"]' >>$GITHUB_OUTPUT
+          digest="$(jq -cr --arg target "${{ inputs.docker_bake_targets }}" '.[$target]["containerimage.digest"] // empty' <<<"$BAKE_METADATA")"
+          if [ -z "$digest" ] || [ "$digest" = "null" ]; then
+            echo "failed to extract container image digest from bake output metadata"
+            exit 1
+          fi
+          echo "digest=$digest" >>$GITHUB_OUTPUT
 
       -
         name: Export digest
@@ -203,7 +210,7 @@ jobs:
 
       -
         name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: ${{ inputs.push_remote_flag }}
         with:
           name: digests-latest-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
@@ -234,7 +241,7 @@ jobs:
 
       -
         name: Download meta bake definition
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           # name: bake-meta
           ## https://github.com/actions/download-artifact/tree/v4?tab=readme-ov-file#breaking-changes
@@ -244,7 +251,7 @@ jobs:
 
       -
         name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           # name: digests
           ## https://github.com/actions/download-artifact/tree/v4?tab=readme-ov-file#breaking-changes

--- a/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
@@ -116,7 +116,17 @@ jobs:
         name: Rename meta bake definition file
         run: |
           mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
-          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          jq '
+            def scrub:
+              if type == "object" then
+                with_entries(select(.key != "buildx.build.provenance") | .value |= scrub)
+              elif type == "array" then
+                map(scrub)
+              else
+                .
+              end;
+            scrub
+          ' "${{ steps.meta.outputs.bake-file }}" > "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition

--- a/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
@@ -130,7 +130,7 @@ jobs:
 
       -
         name: Upload meta bake definition
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: ${{ inputs.push_remote_flag }}
         with:
           name: bake-tag-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
@@ -189,8 +189,15 @@ jobs:
 
       - name: Extract container image digest from bake output
         id: bake-output-container-image-digest
+        env:
+          BAKE_METADATA: ${{ steps.bake.outputs.metadata }}
         run: |
-          jq '.' "${{ runner.temp }}/${{ inputs.docker_bake_targets }}/bake-meta.json" | jq -cr '.["${{ inputs.docker_bake_targets }}"]["containerimage.digest"]' >>$GITHUB_OUTPUT
+          digest="$(jq -cr --arg target "${{ inputs.docker_bake_targets }}" '.[$target]["containerimage.digest"] // empty' <<<"$BAKE_METADATA")"
+          if [ -z "$digest" ] || [ "$digest" = "null" ]; then
+            echo "failed to extract container image digest from bake output metadata"
+            exit 1
+          fi
+          echo "digest=$digest" >>$GITHUB_OUTPUT
 
       -
         name: Export digest
@@ -202,7 +209,7 @@ jobs:
 
       -
         name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: ${{ inputs.push_remote_flag }}
         with:
           name: digests-tag-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
@@ -233,7 +240,7 @@ jobs:
 
       -
         name: Download meta bake definition
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           # name: bake-meta
           ## https://github.com/actions/download-artifact/tree/v4?tab=readme-ov-file#breaking-changes
@@ -243,7 +250,7 @@ jobs:
 
       -
         name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           # name: digests
           ## https://github.com/actions/download-artifact/tree/v4?tab=readme-ov-file#breaking-changes

--- a/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
@@ -190,17 +190,7 @@ jobs:
       - name: Extract container image digest from bake output
         id: bake-output-container-image-digest
         run: |
-          jq '
-            def scrub:
-              if type == "object" then
-                with_entries(select(.key != "buildx.build.provenance") | .value |= scrub)
-              elif type == "array" then
-                map(scrub)
-              else
-                .
-              end;
-            scrub
-          ' "${{ steps.meta.outputs.bake-file }}" | jq -cr '.["${{ inputs.docker_bake_targets }}"]["containerimage.digest"]')" >>$GITHUB_OUTPUT
+          jq '.' "${{ runner.temp }}/${{ inputs.docker_bake_targets }}/bake-meta.json" | jq -cr '.["${{ inputs.docker_bake_targets }}"]["containerimage.digest"]' >>$GITHUB_OUTPUT
 
       -
         name: Export digest

--- a/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
@@ -190,7 +190,17 @@ jobs:
       - name: Extract container image digest from bake output
         id: bake-output-container-image-digest
         run: |
-          echo "digest=$(echo '${{ steps.bake.outputs.metadata}}' | jq -cr '.["${{ inputs.docker_bake_targets }}"]["containerimage.digest"]')" >>$GITHUB_OUTPUT
+          jq '
+            def scrub:
+              if type == "object" then
+                with_entries(select(.key != "buildx.build.provenance") | .value |= scrub)
+              elif type == "array" then
+                map(scrub)
+              else
+                .
+              end;
+            scrub
+          ' "${{ steps.meta.outputs.bake-file }}" | jq -cr '.["${{ inputs.docker_bake_targets }}"]["containerimage.digest"]')" >>$GITHUB_OUTPUT
 
       -
         name: Export digest


### PR DESCRIPTION
### Description of Changes

- Modify the renaming process of the meta bake definition file to scrub sensitive information.
- Use jq to filter out the "buildx.build.provenance" key from the JSON output, ensuring that sensitive data is not included in the final bake-meta.json file.

### Related Issues

List related issues here

- #109